### PR TITLE
Store an instance of ParsedownExtra in GlobalContainer instead of using ParsedownExtra::instance()

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -64,6 +64,14 @@ GlobalContainer::set(array(
 ));
 
 /**
+ * Initialize ParsedownExtra instance
+ */
+
+GlobalContainer::set(array(
+	'parsedown-extra' => new ParsedownExtra()
+));
+
+/**
  * Print requested page
  */
 if ($page) {

--- a/template.php
+++ b/template.php
@@ -149,7 +149,7 @@ function params($key, $default = null)
 function get_text($string)
 {
 	if (ConfigContainer::get('markdown')) {
-		return shortcodes(ConfigContainer::get('parsedown-extra')->text($string));
+		return shortcodes(GlobalContainer::get('parsedown-extra')->text($string));
 	} else {
 		return shortcodes($string);
 	}

--- a/template.php
+++ b/template.php
@@ -149,7 +149,7 @@ function params($key, $default = null)
 function get_text($string)
 {
 	if (ConfigContainer::get('markdown')) {
-		return shortcodes(ParsedownExtra::instance()->text($string));
+		return shortcodes(ConfigContainer::get('parsedown-extra')->text($string));
 	} else {
 		return shortcodes($string);
 	}

--- a/template.php
+++ b/template.php
@@ -11,7 +11,6 @@
 use Pronto\ConfigContainer;
 use Pronto\GlobalContainer;
 use Pronto\HelperContainer;
-use \ParsedownExtra;
 
 /**
  * Fill template with data and print the generated contents


### PR DESCRIPTION
We need this for advanced Parsedown features like footnotes.
